### PR TITLE
Fix 0x503 field offsets and add 0x5F0-0x5F4 cell voltage support

### DIFF
--- a/src/samsung_sdi_bms_service.py
+++ b/src/samsung_sdi_bms_service.py
@@ -134,6 +134,13 @@ class SamsungSDIMonitor:
             self.dbus_service.add_path('/System/MinCellTemperature', None, writeable=False)
             self.dbus_service.add_path('/System/MaxCellTemperature', None, writeable=False)
 
+            # Individual cell voltages (0x5F0-0x5F4), dbus-serialbattery
+            # path convention so existing GUI mods display them.
+            for _cell in range(1, 15):
+                self.dbus_service.add_path(f'/Voltages/Cell{_cell}', None, writeable=False)
+            self.dbus_service.add_path('/Voltages/Sum', None, writeable=False)
+            self.dbus_service.add_path('/Voltages/Diff', None, writeable=False)
+
             # History
             self.dbus_service.add_path('/History/ChargeCycles', None, writeable=False)
             self.dbus_service.add_path('/History/TotalAhDrawn', None, writeable=False)
@@ -174,6 +181,7 @@ class SamsungSDIMonitor:
             max_cell_temperature = self.sdi_client.get_max_cell_temperature()
             charge_current_limit = self.sdi_client.get_charge_current_limit()
             discharge_current_limit = self.sdi_client.get_discharge_current_limit()
+            cell_voltages = self.sdi_client.get_cell_voltages()
 
             if voltage is None or current is None or soc is None:
                 logger.warning(f"System {self.system_id}: Incomplete data received")
@@ -190,7 +198,8 @@ class SamsungSDIMonitor:
                 'min_cell_temperature': min_cell_temperature,
                 'max_cell_temperature': max_cell_temperature,
                 'charge_current_limit': charge_current_limit,
-                'discharge_current_limit': discharge_current_limit
+                'discharge_current_limit': discharge_current_limit,
+                'cell_voltages': cell_voltages
             }
 
             # Update D-Bus
@@ -256,6 +265,15 @@ class SamsungSDIMonitor:
                 self.dbus_service['/System/MinCellTemperature'] = system_data['min_cell_temperature']
             if 'max_cell_temperature' in system_data and system_data['max_cell_temperature'] is not None:
                 self.dbus_service['/System/MaxCellTemperature'] = system_data['max_cell_temperature']
+
+            # Publish individual cell voltages (0x5F0-0x5F4)
+            cells = system_data.get('cell_voltages') or {}
+            if cells:
+                for _cell in range(1, 15):
+                    self.dbus_service[f'/Voltages/Cell{_cell}'] = cells.get(_cell)
+                self.dbus_service['/Voltages/Sum'] = round(sum(cells.values()), 3)
+                self.dbus_service['/Voltages/Diff'] = round(
+                    max(cells.values()) - min(cells.values()), 3)
 
             logger.debug(f"Node {self.system_id}: V={system_data.get('voltage', 0):.2f}V, "
                         f"I={system_data.get('current', 0):.2f}A, "

--- a/src/samsung_sdi_can_client.py
+++ b/src/samsung_sdi_can_client.py
@@ -72,17 +72,79 @@ class SamsungSDICANClient:
                 'max_cell_voltage': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Maximum cell voltage in all tray'},
                 'min_cell_voltage': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Minimum cell voltage in all tray'},
                 'avg_tray_voltage': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.01, 'unit': 'V', 'description': 'Average tray voltage in all tray'},
-                'max_tray_voltage': {'byte_offset': 8, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.01, 'unit': 'V', 'description': 'Maximum tray voltage in all tray'},
-                'min_tray_voltage': {'byte_offset': 10, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.01, 'unit': 'V', 'description': 'Minimum tray voltage in all tray'},
             }
         ),
         0x504: CANMessageDefinition(
             can_id=0x504,
             name="Temperature Summary",
             fields={
+                # Spec Rev 0.2 Table 8: max/min tray voltage are bytes 0-3
+                # of 0x504 (previously mis-filed at offsets 8/10 of 0x503,
+                # which exceed the 8-byte CAN 2.0A frame).
+                'max_tray_voltage': {'byte_offset': 0, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.01, 'unit': 'V', 'description': 'Maximum tray voltage in all tray'},
+                'min_tray_voltage': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.01, 'unit': 'V', 'description': 'Minimum tray voltage in all tray'},
                 'avg_cell_temp': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'S8', 'scale': 1.0, 'unit': '°C', 'description': 'Average cell temperature in all tray'},
                 'max_cell_temp': {'byte_offset': 5, 'bit_offset': None, 'data_type': 'S8', 'scale': 1.0, 'unit': '°C', 'description': 'Maximum cell temperature in all tray'},
                 'min_cell_temp': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'S8', 'scale': 1.0, 'unit': '°C', 'description': 'Minimum cell temperature in all tray'},
+            }
+        ),
+        0x5F0: CANMessageDefinition(
+            can_id=0x5F0,
+            name="Cell Voltages 1-3",
+            fields={
+                # Byte 0-1 carries the Tray-ID (U16). Single-tray systems
+                # can ignore it; multi-tray cell reporting would need
+                # per-tray keying and is out of scope for this patch.
+                'cell_voltage_01': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #1 voltage'},
+                'cell_voltage_02': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #2 voltage'},
+                'cell_voltage_03': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #3 voltage'},
+            }
+        ),
+        0x5F1: CANMessageDefinition(
+            can_id=0x5F1,
+            name="Cell Voltages 4-6",
+            fields={
+                # Byte 0-1 carries the Tray-ID (U16). Single-tray systems
+                # can ignore it; multi-tray cell reporting would need
+                # per-tray keying and is out of scope for this patch.
+                'cell_voltage_04': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #4 voltage'},
+                'cell_voltage_05': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #5 voltage'},
+                'cell_voltage_06': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #6 voltage'},
+            }
+        ),
+        0x5F2: CANMessageDefinition(
+            can_id=0x5F2,
+            name="Cell Voltages 7-9",
+            fields={
+                # Byte 0-1 carries the Tray-ID (U16). Single-tray systems
+                # can ignore it; multi-tray cell reporting would need
+                # per-tray keying and is out of scope for this patch.
+                'cell_voltage_07': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #7 voltage'},
+                'cell_voltage_08': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #8 voltage'},
+                'cell_voltage_09': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #9 voltage'},
+            }
+        ),
+        0x5F3: CANMessageDefinition(
+            can_id=0x5F3,
+            name="Cell Voltages 10-12",
+            fields={
+                # Byte 0-1 carries the Tray-ID (U16). Single-tray systems
+                # can ignore it; multi-tray cell reporting would need
+                # per-tray keying and is out of scope for this patch.
+                'cell_voltage_10': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #10 voltage'},
+                'cell_voltage_11': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #11 voltage'},
+                'cell_voltage_12': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #12 voltage'},
+            }
+        ),
+        0x5F4: CANMessageDefinition(
+            can_id=0x5F4,
+            name="Cell Voltages 13-14",
+            fields={
+                # Byte 0-1 carries the Tray-ID (U16). Single-tray systems
+                # can ignore it; multi-tray cell reporting would need
+                # per-tray keying and is out of scope for this patch.
+                'cell_voltage_13': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #13 voltage'},
+                'cell_voltage_14': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U16', 'scale': 0.001, 'unit': 'V', 'description': 'Cell #14 voltage'},
             }
         ),
     }
@@ -129,6 +191,11 @@ class SamsungSDICANClient:
                 byte_offset = field_info['byte_offset']
                 data_type = field_info['data_type']
                 scale = field_info['scale']
+
+                width = 2 if data_type in ('U16', 'S16') else 1
+                if byte_offset + width > len(data):
+                    # Field lies beyond this frame's DLC — skip silently.
+                    continue
 
                 if data_type == 'U8':
                     raw_value = data[byte_offset]
@@ -254,6 +321,20 @@ class SamsungSDICANClient:
         """Get maximum cell temperature"""
         data = self.read_battery_data()
         return data.get('max_cell_temp')
+
+    def get_cell_voltages(self) -> Dict[int, float]:
+        """Individual cell voltages {cell_number: volts} from 0x5F0-0x5F4.
+
+        Returns an empty dict if the battery firmware does not broadcast
+        the cell frames. Zero readings (unpopulated slots) are omitted.
+        """
+        data = self.read_battery_data()
+        cells = {}
+        for n in range(1, 15):
+            v = data.get('cell_voltage_%02d' % n)
+            if v:
+                cells[n] = v
+        return cells
 
     def is_connected(self) -> bool:
         """Check if CAN bus is connected and receiving data"""


### PR DESCRIPTION
# PR description

Fixes #18

## What this does

**1. Corrects the 0x503 definition.** `max_tray_voltage`/`min_tray_voltage`
were defined at byte offsets 8/10 — beyond the 8-byte CAN 2.0A frame — so
they could never decode and produced a WARNING log line on every 0x503
frame (~2 Hz). Per the ELPM482-00005 spec Rev 0.2 Table 8 these fields are
bytes 0-1/2-3 of **0x504**; this PR moves them there.

**2. Adds the individual cell voltage frames 0x5F0-0x5F4** (14 cells,
3 per frame, Tray-ID in bytes 0-1) and publishes them to D-Bus using the
dbus-serialbattery path convention (`/Voltages/Cell1`..`Cell14`,
`/Voltages/Sum`, `/Voltages/Diff`) so existing GUI mods display them
unmodified. Zero readings (unpopulated slots / 0x5F4 padding) are
filtered.

**3. Adds a frame-length guard** in `_parse_can_message()`: any field
whose `byte_offset + width` exceeds the received data length is skipped
silently — removes the log spam and hardens every message definition
against short frames.

## Validation

- Verified against live captures from a real ELPM482-00005
  (`5F0: 01 00 C0 0D C1 0D C2 0D` → cells 3.520/3.521/3.522 V, matching
  the module's 0x503 min/max).
- All field definitions now provably fit an 8-byte frame (bounds-checked
  programmatically).
- Known limitation, documented in the code: cell frames are keyed by
  Tray-ID in the payload; the flat merge here is correct for single-tray
  systems. Multi-tray cell reporting needs per-tray keying — out of scope
  for this PR.