### PR TITLE
Mark battery disconnected on D-Bus when CAN data goes stale (fixes #19)

### DIFF
--- a/src/samsung_sdi_bms_service.py
+++ b/src/samsung_sdi_bms_service.py
@@ -69,6 +69,7 @@ class SamsungSDIMonitor:
         self.dbus_service: Optional[VeDbusService] = None
         self.last_update = 0
         self.last_update = 0
+        self._connected = True  # mirrors /Connected; see _set_connected()
         self.firmware_updater = None
 
     def setup_dbus(self) -> bool:
@@ -160,6 +161,30 @@ class SamsungSDIMonitor:
             logger.error(f"Node {self.system_id}: Failed to initialize D-Bus service: {e}")
             return False
 
+    def _set_connected(self, connected: bool):
+        """Reflect the CAN link state on D-Bus.
+
+        Without this, the last published values persist indefinitely on
+        CAN loss and the GX keeps showing a stale-but-live-looking
+        battery (issue #19). While disconnected, charge/discharge
+        current limits are forced to 0 A so nothing keeps acting on
+        stale limits.
+        """
+        if self.dbus_service is None or self._connected == connected:
+            return
+        self._connected = connected
+        if connected:
+            self.dbus_service['/Connected'] = 1
+            logger.info(f"System {self.system_id}: CAN data restored - "
+                        f"battery reconnected on D-Bus")
+        else:
+            self.dbus_service['/Connected'] = 0
+            self.dbus_service['/Info/MaxChargeCurrent'] = 0.0
+            self.dbus_service['/Info/MaxDischargeCurrent'] = 0.0
+            logger.warning(f"System {self.system_id}: CAN data stale - "
+                           f"marking battery disconnected on D-Bus and "
+                           f"forcing charge/discharge limits to 0 A")
+
     def update(self) -> bool:
         """Update Samsung SDI system data"""
         try:
@@ -177,6 +202,7 @@ class SamsungSDIMonitor:
 
             if voltage is None or current is None or soc is None:
                 logger.warning(f"System {self.system_id}: Incomplete data received")
+                self._set_connected(False)
                 return False
 
             # Create data dict for D-Bus update
@@ -195,6 +221,7 @@ class SamsungSDIMonitor:
 
             # Update D-Bus
             if self.dbus_service:
+                self._set_connected(True)
                 self._update_dbus(system_data)
 
             self.last_update = time.time()


### PR DESCRIPTION
# PR description
<img width="4032" height="3024" alt="IMG_2454" src="https://github.com/user-attachments/assets/5c5048c1-0e52-48d0-a2b1-b538d7997900" />


Fixes #19

## Problem

On CAN loss, `SamsungSDICANClient` correctly clears its internal cache
after the timeout, but the service layer never reflects this on D-Bus:
`update()` logs "Incomplete data received" and returns False, while
`/Connected` stays 1 and the last published voltage/SOC/limits persist
indefinitely. The GX (and DVCC, if this service is the selected battery
monitor) continues to see a live-looking battery with frozen values.

Reproduced on hardware 06-07-2026 (Cerbo GX MK2, Venus OS v3.70, real
ELPM482-00005): with the CAN cable unplugged, the battery remained in
the Device List showing 48.90 V / SOC 11 % / "Idle" as a connected
device for the full test duration — photo attached to issue #19.

## Fix

Adds a small `_set_connected()` helper and wires it into `update()`:

- **Stale path** (voltage/current/soc None after the client's timeout):
  `/Connected` → 0, and `/Info/MaxChargeCurrent` /
  `/Info/MaxDischargeCurrent` → 0.0 A, so nothing downstream keeps
  acting on frozen limits. Logged once per transition (no log spam).
- **Recovery path**: on the first complete data set, `/Connected` → 1
  before values are republished. Fully automatic, no restart needed.

State is edge-triggered via a `_connected` flag, so the D-Bus writes
happen only on transitions.

## Validation

- Cable-pull on live hardware: D-Bus flips to disconnected within the
  client timeout; GX drops the battery; replug restores it unaided.
- `python3 -m py_compile` clean; diff is minimal (4 hunks) and touches
  only `samsung_sdi_bms_service.py`.
- Out of scope, noted for completeness: the aggregator service has the
  same exposure and can adopt the identical helper; happy to follow up
  if wanted.