### PR TITLE
Publish BMS alarms from 0x501 bitfields (fixes #20)

### DIFF
--- a/src/samsung_sdi_bms_service.py
+++ b/src/samsung_sdi_bms_service.py
@@ -174,6 +174,8 @@ class SamsungSDIMonitor:
             max_cell_temperature = self.sdi_client.get_max_cell_temperature()
             charge_current_limit = self.sdi_client.get_charge_current_limit()
             discharge_current_limit = self.sdi_client.get_discharge_current_limit()
+            alarm_bits = self.sdi_client.get_alarm_status() or 0
+            protection_bits = self.sdi_client.get_protection_status() or 0
 
             if voltage is None or current is None or soc is None:
                 logger.warning(f"System {self.system_id}: Incomplete data received")
@@ -190,7 +192,9 @@ class SamsungSDIMonitor:
                 'min_cell_temperature': min_cell_temperature,
                 'max_cell_temperature': max_cell_temperature,
                 'charge_current_limit': charge_current_limit,
-                'discharge_current_limit': discharge_current_limit
+                'discharge_current_limit': discharge_current_limit,
+                'alarm_bits': int(alarm_bits),
+                'protection_bits': int(protection_bits)
             }
 
             # Update D-Bus
@@ -204,8 +208,64 @@ class SamsungSDIMonitor:
             logger.error(f"System {self.system_id}: Update error: {e}")
             return False
 
+
+    # Samsung 0x501 bit positions (spec Rev 0.2 Table 8), shared by the
+    # alarm bitfield (bytes 0-1) and protection bitfield (bytes 2-3):
+    #   bit0 Over-Voltage        bit1 Under-Voltage
+    #   bit2 Over-Temperature    bit3 Under-Temperature
+    #   bit4 Charge Over-Current bit5 Discharge Over-Current
+    #   bit6 FET Over-Temp       bit7 Tray Voltage Imbalance
+    # Protection high byte: bit8 Tray-ID err, bit9 PCS comm, bit10 FET
+    # failure, bit11 FET OT failure, bit12 UV shutdown, bit13 cell
+    # imbalance, bit14 2nd Over-Voltage.
+    _ALARM_BIT_PATHS = {
+        0: '/Alarms/HighVoltage',
+        1: '/Alarms/LowVoltage',
+        2: '/Alarms/HighTemperature',
+        3: '/Alarms/LowTemperature',
+        4: '/Alarms/HighChargeCurrent',
+        5: '/Alarms/HighDischargeCurrent',
+        6: '/Alarms/InternalFailure',
+        7: '/Alarms/CellImbalance',
+    }
+    _PROTECTION_EXTRA_PATHS = {
+        12: '/Alarms/LowVoltage',      # UV shutdown
+        13: '/Alarms/CellImbalance',   # cell voltage imbalance
+        14: '/Alarms/HighVoltage',     # 2nd over-voltage
+    }
+
+    def _update_alarms(self, alarm_bits: int, protection_bits: int):
+        """Map 0x501 bitfields to /Alarms/* paths.
+
+        Victron convention: 0 = OK, 1 = warning, 2 = alarm. Samsung
+        alarm bits (BMS warning, FETs still closed) map to 1; protection
+        bits (BMS has acted) map to 2 on the same categories. Any
+        protection high-byte condition also raises InternalFailure.
+        Writes only on change to avoid D-Bus churn.
+        """
+        if self.dbus_service is None:
+            return
+        values = {path: 0 for path in self._ALARM_BIT_PATHS.values()}
+        for bit, path in self._ALARM_BIT_PATHS.items():
+            if alarm_bits & (1 << bit):
+                values[path] = max(values[path], 1)
+            if protection_bits & (1 << bit):
+                values[path] = max(values[path], 2)
+        for bit, path in self._PROTECTION_EXTRA_PATHS.items():
+            if protection_bits & (1 << bit):
+                values[path] = max(values[path], 2)
+        if protection_bits & 0x7F00:
+            values['/Alarms/InternalFailure'] = 2
+        cache = getattr(self, '_alarm_cache', {})
+        for path, value in values.items():
+            if cache.get(path) != value:
+                self.dbus_service[path] = value
+        self._alarm_cache = values
+
     def _update_dbus(self, system_data: Dict[str, Any]):
         """Update D-Bus paths with Samsung SDI system data"""
+        self._update_alarms(system_data.get('alarm_bits', 0),
+                            system_data.get('protection_bits', 0))
         try:
             # Essential battery data
             if 'voltage' in system_data:

--- a/src/samsung_sdi_can_client.py
+++ b/src/samsung_sdi_can_client.py
@@ -41,14 +41,18 @@ class SamsungSDICANClient:
                 'system_soc': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U8', 'scale': 1.0, 'unit': '%', 'description': 'Average SOC in all tray'},
                 'system_soh': {'byte_offset': 5, 'bit_offset': None, 'data_type': 'U8', 'scale': 1.0, 'unit': '%', 'description': 'Average SOH in all tray'},
                 'system_heartbeat': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U16', 'scale': 1.0, 'unit': 'dec', 'description': 'Heart-Beat Value'},
-                'alarm_status': {'byte_offset': 0, 'bit_offset': 0, 'data_type': 'BITFIELD8', 'scale': 1.0, 'unit': '', 'description': 'System Alarm Status'},
-                'protection_status': {'byte_offset': 2, 'bit_offset': 0, 'data_type': 'BITFIELD8', 'scale': 1.0, 'unit': '', 'description': 'System Protection Status'},
             }
         ),
         0x501: CANMessageDefinition(
             can_id=0x501,
             name="System Configuration",
             fields={
+                # Spec Rev 0.2 Table 8: System Alarm Status is 0x501
+                # bytes 0-1 and System Protection Status bytes 2-3.
+                # (Previously mis-sourced from 0x500 bytes 0/2, which are
+                # the voltage low byte and current - issue #20.)
+                'alarm_status': {'byte_offset': 0, 'bit_offset': None, 'data_type': 'U16', 'scale': 1.0, 'unit': '', 'description': 'System Alarm Status bitfield'},
+                'protection_status': {'byte_offset': 2, 'bit_offset': None, 'data_type': 'U16', 'scale': 1.0, 'unit': '', 'description': 'System Protection Status bitfield'},
                 'total_trays': {'byte_offset': 4, 'bit_offset': None, 'data_type': 'U8', 'scale': 1.0, 'unit': 'EA', 'description': 'Number of Total Tray'},
                 'normal_trays': {'byte_offset': 5, 'bit_offset': None, 'data_type': 'U8', 'scale': 1.0, 'unit': 'EA', 'description': 'Number of Normal Operating Tray'},
                 'fault_trays': {'byte_offset': 6, 'bit_offset': None, 'data_type': 'U8', 'scale': 1.0, 'unit': 'EA', 'description': 'Number of Fault Tray'},
@@ -229,6 +233,11 @@ class SamsungSDICANClient:
         """Get discharge current limitation"""
         data = self.read_battery_data()
         return data.get('discharge_current_limit')
+
+    def get_protection_status(self) -> Optional[int]:
+        """Get protection status bitfield (0x501 bytes 2-3)"""
+        data = self.read_battery_data()
+        return data.get('protection_status')
 
     def get_alarm_status(self) -> Optional[int]:
         """Get alarm status bitfield"""


### PR DESCRIPTION
# PR description
<img width="3024" height="4032" alt="IMG_2462" src="https://github.com/user-attachments/assets/d4147f7b-d3db-4d49-a197-2afabbfe7293" />


Fixes #20

## Problem (two halves)

1. All thirteen `/Alarms/*` paths are registered at startup but no code
   path ever writes them — genuine BMS alarm/protection conditions never
   reach the GX, VRM, or notifications.
2. The underlying data was mis-sourced: `alarm_status`/`protection_status`
   were defined as bytes 0/2 of **0x500**, which per the ELPM482-00005
   spec Rev 0.2 Table 8 are the System Voltage low byte and System
   Current. The real bitfields are **0x501 bytes 0-1 (alarm) and 2-3
   (protection)**. Simply wiring the existing getters to the paths would
   therefore have published voltage-derived garbage (e.g. 51.23 V →
   0x1403 → low byte 0x03 → simultaneous phantom high- and low-voltage
   alarms flickering with pack voltage). Same root cause as the C-driver
   alarm-source issue.

## Fix

**Client:** moves `alarm_status`/`protection_status` to 0x501 as U16
bitfields at their spec offsets; adds `get_protection_status()`.

**Service:** adds `_update_alarms()` mapping the bitfields to the
already-registered paths using the Victron convention (0 = OK,
1 = warning, 2 = alarm): Samsung *alarm* bits (BMS warning, FETs closed)
→ 1; *protection* bits (BMS has acted) → 2 on the same categories;
protection high-byte conditions additionally raise `InternalFailure`,
with UV-shutdown / cell-imbalance / 2nd-OV also mapped to their specific
paths. Writes are change-detected to avoid D-Bus churn.

## Validation

- Bit-category mapping is the same one validated on hardware 06-07-2026
  (Cerbo GX MK2, Venus v3.70, real ELPM482-00005): injecting 0x501 with
  alarm bit 2 produced a correctly-named "High Temperature" notification
  on the GX; the protection bit escalated severity.
- Mapping logic behaviour-tested (warning→1, protection→2, high-byte →
  InternalFailure + specific path, all-clear resets).
- `py_compile` clean on both files; 5 hunks total.
- Note: this PR touches lines adjacent to PR "stale /Connected"
  (fixes #19) — if both are open, whichever merges second may need a
  trivial rebase; happy to do it.